### PR TITLE
Add comprehensive tests for C library and Dart FFI

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,62 @@ cd Encryption-with-dart-ffi
 pub get
 ```
 
+## Building and Running Tests
 
+This project includes unit tests for the C encryption library and integration tests for the Dart FFI calls.
+
+### 1. C Unit Tests
+
+The C unit tests verify the core encryption, decryption, and key generation logic.
+
+**Prerequisites:**
+*   CMake (version 3.10 or higher)
+*   A C compiler (e.g., GCC, Clang)
+*   Make (or your chosen CMake build tool)
+
+**Steps to build and run:**
+
+1.  Navigate to the `encryption_library` directory:
+    ```bash
+    cd encryption_library
+    ```
+2.  Configure the build using CMake:
+    ```bash
+    cmake .
+    ```
+3.  Build the tests (and the library):
+    ```bash
+    make
+    ```
+4.  Run the C tests:
+    ```bash
+    ctest
+    ```
+    Or, you can directly run the test executable:
+    ```bash
+    ./run_c_tests 
+    ```
+    (On Windows, it might be `.\Debug\run_c_tests.exe` or `.\Release\run_c_tests.exe` depending on the build configuration).
+
+    You should see output indicating whether the tests passed or failed.
+
+### 2. Dart FFI Integration Tests
+
+The Dart tests verify that the Dart code correctly interacts with the C library via FFI.
+
+**Prerequisites:**
+*   Dart SDK (version specified in `pubspec.yaml`, e.g., '>=2.19.0 <3.0.0')
+*   Ensure the C library (`libencryption.so`, `libencryption.dylib`, or `encryption.dll`) has been built. You can do this by following steps 1-3 for the C Unit Tests above, as building `make` in `encryption_library` should also produce the shared library.
+
+**Steps to run:**
+
+1.  Navigate to the root project directory (if you're not already there).
+2.  Get the Dart dependencies:
+    ```bash
+    dart pub get
+    ```
+3.  Run the Dart tests:
+    ```bash
+    dart test
+    ```
+    This command will discover and run tests in the `test/` directory. You should see output indicating the results of the tests.

--- a/encryption_library/CMakeLists.txt
+++ b/encryption_library/CMakeLists.txt
@@ -1,7 +1,18 @@
-cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.7 FATAL_ERROR) # Keep or update to 3.10 if specific features are needed, 3.7 is fine.
+include(CTest) # For CTest integration
+
 project(encryption_library VERSION 1.0.0 LANGUAGES C)
+enable_testing() # Enable testing framework
+
 add_library(encryption_library SHARED encryption.c encryption.def)
-add_executable(encryption_test encryption.c)
+# Remove the old executable: add_executable(encryption_test encryption.c)
+
+# Add executable for C unit tests
+# This compiles encryption.c and test_encryption.c together into one executable
+add_executable(run_c_tests test_encryption.c encryption.c)
+
+# Add the test to CTest
+add_test(NAME CEncryptionTests COMMAND run_c_tests)
 
 set_target_properties(encryption_library PROPERTIES
     PUBLIC_HEADER encryption.h

--- a/encryption_library/test_encryption.c
+++ b/encryption_library/test_encryption.c
@@ -1,0 +1,105 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h> // Added for strcmp and strcpy
+#include <time.h>
+#include "encryption.h"
+
+// Test function for generateKey
+int test_generateKey() {
+    int errors = 0;
+    int key;
+    for (int i = 0; i < 100; i++) {
+        key = generateKey();
+        if (key < 0 || key > 10) {
+            fprintf(stderr, "Error: generateKey() produced out-of-range key: %d\n", key);
+            errors++;
+        }
+    }
+    return errors;
+}
+
+// Structure for encryption/decryption test cases
+typedef struct {
+    char* original;
+    int key;
+    char* description;
+} TestCase;
+
+// Test function for encryption and decryption
+int test_encryption_decryption() {
+    int errors = 0;
+
+    TestCase tests[] = {
+        {"hello", 3, "Simple lowercase string"},
+        {"HeLLo", 5, "Mixed case string"},
+        {"test123", 7, "String with numbers"},
+        {"", 2, "Empty string"},
+        {"world", 10, "String with max key"},
+        {"nochange", 0, "String with key 0"}
+    };
+    int num_tests = sizeof(tests) / sizeof(tests[0]);
+
+    for (int i = 0; i < num_tests; i++) {
+        char* original_str = tests[i].original;
+        int key = tests[i].key;
+        int len = strlen(original_str);
+
+        // Encryption allocates new memory
+        char* encrypted_output = encryption(original_str, len, key);
+        if (encrypted_output == NULL) {
+            fprintf(stderr, "Error in test: %s\n", tests[i].description);
+            fprintf(stderr, "  encryption() returned NULL for original: '%s', key: %d\n", original_str, key);
+            errors++;
+            continue; // Skip to next test case
+        }
+
+        // Decryption allocates new memory
+        char* decrypted_output = decryption(encrypted_output, len, key);
+        if (decrypted_output == NULL) {
+            fprintf(stderr, "Error in test: %s\n", tests[i].description);
+            fprintf(stderr, "  decryption() returned NULL for encrypted: '%s', key: %d\n", encrypted_output, key);
+            errors++;
+            free(encrypted_output); // Free memory allocated by encryption
+            continue; // Skip to next test case
+        }
+
+        if (strcmp(original_str, decrypted_output) != 0) {
+            fprintf(stderr, "Error in test: %s\n", tests[i].description);
+            fprintf(stderr, "  Original:   '%s'\n", original_str);
+            fprintf(stderr, "  Key:        %d\n", key);
+            fprintf(stderr, "  Encrypted:  '%s'\n", encrypted_output);
+            fprintf(stderr, "  Decrypted:  '%s' (should be '%s')\n", decrypted_output, original_str);
+            errors++;
+        }
+        
+        // Free memory allocated by encryption and decryption
+        free(encrypted_output);
+        free(decrypted_output);
+    }
+    return errors;
+}
+
+
+int main() {
+    // Seed the random number generator
+    srand(time(NULL));
+
+    int key_errors = test_generateKey();
+    int enc_dec_errors = test_encryption_decryption();
+
+    int total_errors = key_errors + enc_dec_errors;
+
+    if (total_errors == 0) {
+        printf("All tests passed.\n");
+    } else {
+        if (key_errors > 0) {
+            printf("generateKey tests failed with %d errors.\n", key_errors);
+        }
+        if (enc_dec_errors > 0) {
+            printf("Encryption/Decryption tests failed with %d errors.\n", enc_dec_errors);
+        }
+        printf("Total errors: %d.\n", total_errors);
+    }
+
+    return (total_errors == 0) ? 0 : 1;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,10 +3,10 @@ version: 0.0.1
 description: >-
   A super simple example of encrypting a message via C code from Dart with FFI
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: '>=2.19.0 <3.0.0' # Updated SDK constraint
 dependencies:
-  ffi: ^0.1.3
+  ffi: ^2.0.1 # Updated ffi version
 dev_dependencies:
-  test: ^1.5.3
+  test: ^1.21.0 # Updated test version
 dependency_overrides:
   analyzer: 0.39.1

--- a/test/encryption_test.dart
+++ b/test/encryption_test.dart
@@ -1,0 +1,122 @@
+import 'dart:ffi';
+import 'package:ffi/ffi.dart';
+import 'dart:io' show Platform;
+import 'package:test/test.dart';
+
+// FFI type definitions (copied from encryption.dart)
+typedef GenerateKeyFunc = Int32 Function();
+typedef GenerateKey = int Function();
+
+typedef EncryptionFunc = Pointer<Utf8> Function(Pointer<Utf8> msg, Int32 length, Int32 key);
+typedef Encryption = Pointer<Utf8> Function(Pointer<Utf8> msg, int length, int key);
+
+typedef DecryptionFunc = Pointer<Utf8> Function(Pointer<Utf8> msg, Int32 length, Int32 key);
+typedef Decryption = Pointer<Utf8> Function(Pointer<Utf8> msg, int length, int key);
+
+// Helper function to open the dynamic library
+DynamicLibrary openEncryptionLibrary() {
+  var path = './encryption_library/libencryption.so'; // For Linux
+  if (Platform.isMacOS) {
+    path = './encryption_library/libencryption.dylib';
+  }
+  if (Platform.isWindows) {
+    // Assuming the DLL is in encryption_library/Debug/encryption.dll as per original encryption.dart
+    // This might need adjustment based on actual CMake build output (e.g., Release folder)
+    path = r'encryption_library\Debug\encryption.dll';
+  }
+  return DynamicLibrary.open(path);
+}
+
+void main() {
+  group('FFI Encryption Tests', () {
+    late DynamicLibrary dylib;
+    late GenerateKey generateKey;
+    late Encryption encryption;
+    late Decryption decryption;
+
+    setUpAll(() {
+      dylib = openEncryptionLibrary();
+
+      final generateKeyPointer = dylib.lookup<NativeFunction<GenerateKeyFunc>>('generateKey');
+      generateKey = generateKeyPointer.asFunction<GenerateKey>();
+
+      final encryptionPointer = dylib.lookup<NativeFunction<EncryptionFunc>>('encryption');
+      encryption = encryptionPointer.asFunction<Encryption>();
+
+      final decryptionPointer = dylib.lookup<NativeFunction<DecryptionFunc>>('decryption');
+      decryption = decryptionPointer.asFunction<Decryption>();
+    });
+
+    test('Library can be opened', () {
+      expect(openEncryptionLibrary, returnsNormally);
+    });
+
+    test('generateKey returns a key within the valid range [0, 10]', () {
+      for (int i = 0; i < 10; i++) {
+        int key = generateKey();
+        expect(key, greaterThanOrEqualTo(0), reason: "Key $key was not >= 0");
+        expect(key, lessThanOrEqualTo(10), reason: "Key $key was not <= 10");
+      }
+    });
+
+    // Define test cases for encryption/decryption
+    final List<Map<String, dynamic>> testCases = [
+      {'description': 'simple lowercase string', 'original': 'hello world', 'key': 3},
+      {'description': 'mixed case string', 'original': 'HeLlO wOrLd', 'key': 5},
+      {'description': 'string with numbers and symbols', 'original': 'Test123!@#\$%', 'key': 7},
+      {'description': 'empty string', 'original': '', 'key': 2},
+      {'description': 'string with key 0 (no change)', 'original': 'nochange', 'key': 0},
+      {'description': 'string with max key (10)', 'original': 'maxkeytest', 'key': 10},
+      // Add a test case that might have been problematic if generateKey() was used directly and produced 0
+      {'description': 'another simple string', 'original': 'another test', 'key': generateKey()}, 
+    ];
+
+    for (final tc in testCases) {
+      test('Encryption/Decryption: ${tc['description']}', () {
+        final String originalMessage = tc['original'];
+        // If key is dynamic (from generateKey), resolve it. Otherwise, use the fixed key.
+        final int key = tc['key'] is int ? tc['key'] : (tc['key'] as GenerateKey)();
+        
+        // Ensure dynamic keys are also within valid range for the test itself
+        if (tc['key'] is GenerateKey) {
+            expect(key, greaterThanOrEqualTo(0), reason: "Generated key $key for test was not >= 0");
+            expect(key, lessThanOrEqualTo(10), reason: "Generated key $key for test was not <= 10");
+        }
+
+        Pointer<Utf8> originalMessageC = nullptr;
+        Pointer<Utf8> encryptedMessageC = nullptr;
+        Pointer<Utf8> encryptedMessageToDecryptC = nullptr;
+        Pointer<Utf8> decryptedMessageC = nullptr;
+
+        try {
+          originalMessageC = originalMessage.toUtf8(allocator: calloc);
+          
+          encryptedMessageC = encryption(originalMessageC, originalMessage.length, key);
+          expect(encryptedMessageC, isNot(nullptr), reason: "Encryption returned null pointer");
+          final encryptedMessageDart = encryptedMessageC.toDartString(length: originalMessage.length); // Specify length for safety, though not strictly needed if null-terminated.
+
+          encryptedMessageToDecryptC = encryptedMessageDart.toUtf8(allocator: calloc);
+
+          decryptedMessageC = decryption(encryptedMessageToDecryptC, encryptedMessageDart.length, key);
+          expect(decryptedMessageC, isNot(nullptr), reason: "Decryption returned null pointer");
+          final decryptedMessageDart = decryptedMessageC.toDartString(length: originalMessage.length);
+
+          expect(decryptedMessageDart, equals(originalMessage),
+              reason: "Decrypted message did not match original. Original: '$originalMessage', Key: $key, Encrypted: '$encryptedMessageDart', Decrypted: '$decryptedMessageDart'");
+        } finally {
+          // Free all allocated C memory
+          if (originalMessageC != nullptr) calloc.free(originalMessageC);
+          // encryptedMessageC and decryptedMessageC are allocated by C functions (assumed via malloc/calloc)
+          // and should be freed by a C free function if not handled by Dart's GC through a special mechanism
+          // or if the C library doesn't expose a free function.
+          // Given the C code uses malloc, and we are in Dart, we must call free on these.
+          // The C functions provided do not have a separate free function, so we assume they return
+          // pointers that should be freed by the standard C `free` (which `calloc.free` can do).
+          if (encryptedMessageC != nullptr) calloc.free(encryptedMessageC);
+          if (encryptedMessageToDecryptC != nullptr) calloc.free(encryptedMessageToDecryptC);
+          if (decryptedMessageC != nullptr) calloc.free(decryptedMessageC);
+        }
+      });
+    }
+  });
+}


### PR DESCRIPTION
This commit introduces a testing framework for the encryption project:

1.  **C Unit Tests:**
    - Added `encryption_library/test_encryption.c` to unit test the `generateKey`, `encryption`, and `decryption` functions.
    - Tests cover key range, encryption/decryption integrity for various inputs (empty strings, different character sets, boundary keys), and memory management for dynamically allocated C strings.
    - Updated `encryption_library/CMakeLists.txt` to build the C tests as an executable (`run_c_tests`) and added a CTest target (`CEncryptionTests`).

2.  **Dart FFI Integration Tests:**
    - Created `test/encryption_test.dart` to test the Dart FFI layer.
    - Tests verify `generateKey` FFI calls and the integrity of `encryption`/`decryption` FFI calls.
    - Dart tests handle string conversions (Dart String <-> C `Pointer<Utf8>`) and ensure proper memory management for pointers obtained from C or allocated by `toUtf8()`.
    - Test cases include various string types, different keys, and empty strings.

3.  **Configuration Updates:**
    - Updated `pubspec.yaml` to include `test` (dev_dependency) and `ffi` (dependency) packages with appropriate versions and SDK constraints.
    - Updated `README.md` with detailed instructions on how to build and run both C and Dart tests.

These tests improve the robustness of the project by ensuring the core logic and the FFI integration work as expected.